### PR TITLE
perf: reduce mobile navigation and rendering cost

### DIFF
--- a/CaddyFile
+++ b/CaddyFile
@@ -2,10 +2,16 @@ luckycc.cc {
         # Set this path to your site's directory.
         root * /var/www/html
 
+        @staticAssets path /_astro/* /fonts/* /avatar.jpeg /defaultAvatar.png /image-1.png /homepage-photo.png /og.png /signature.png /favicon.svg
+        header @staticAssets Cache-Control "public, max-age=31536000, immutable"
+
+        @html path *.html /
+        header @html Cache-Control "public, max-age=0, must-revalidate"
+
         # Enable the static file server.
         file_server
-        redir /posts /posts/1 302
-        redir /thoughts /thoughts/1 302
+        redir /posts /posts/1/ 302
+        redir /thoughts /thoughts/1/ 302
 
         # Another common task is to set up a reverse proxy:
         # reverse_proxy localhost:8080
@@ -13,4 +19,3 @@ luckycc.cc {
         # Or serve a PHP site through php-fpm:
         # php_fastcgi localhost:9000
 }
-

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import path from 'path';
 
 export default defineConfig({
 	integrations: [tailwind(), react()],
+	trailingSlash: 'always',
 	vite: {
 		resolve: {
 			alias: {
@@ -29,7 +30,7 @@ export default defineConfig({
 	},
 	site: 'https://luckycc.cc',
 	redirects: {
-		'/posts': '/posts/1',
-		'/thoughts': '/thoughts/1',
+		'/posts': '/posts/1/',
+		'/thoughts': '/thoughts/1/',
 	},
 });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 		"@astrojs/rss": "^4.0.9",
 		"@astrojs/tailwind": "^5.1.0",
 		"@hookform/resolvers": "^3.9.1",
-		"@lottiefiles/react-lottie-player": "^3.5.4",
 		"@radix-ui/react-avatar": "^1.1.1",
 		"@radix-ui/react-dialog": "^1.1.2",
 		"@radix-ui/react-icons": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ dependencies:
   '@hookform/resolvers':
     specifier: ^3.9.1
     version: 3.9.1(react-hook-form@7.53.2)
-  '@lottiefiles/react-lottie-player':
-    specifier: ^3.5.4
-    version: 3.5.4(react@18.3.1)
   '@radix-ui/react-avatar':
     specifier: ^1.1.1
     version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.7)(react-dom@18.3.1)(react@18.3.1)
@@ -1114,15 +1111,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  /@lottiefiles/react-lottie-player@3.5.4(react@18.3.1):
-    resolution: {integrity: sha512-2FptWtHQ+o7MzdsMKSvNZ1Mz7xtKSYI0WL9HjZ1r+CvsXR3lbLQUDp7Pwx6qhg0Akm4VluQ+8/D1S1fcr1Ao4w==}
-    peerDependencies:
-      react: 16 - 18
-    dependencies:
-      lottie-web: 5.12.2
-      react: 18.3.1
-    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3384,10 +3372,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: false
-
-  /lottie-web@5.12.2:
-    resolution: {integrity: sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg==}
     dev: false
 
   /lru-cache@10.4.3:

--- a/src/components/Article/PostCollection.astro
+++ b/src/components/Article/PostCollection.astro
@@ -22,7 +22,7 @@ const { posts } = Astro.props;
 			})
 			.map((article, i) => {
 				return (
-					<BlurFade className="flex justify-start gap-2 items-center" client:load delay={0.1 * i}>
+					<BlurFade className="flex justify-start gap-2 items-center" client:visible delay={0.1 * i}>
 						<PostItem
 							title={article.frontmatter.title}
 							href={article.url}

--- a/src/components/Comments/CommentsCollection.tsx
+++ b/src/components/Comments/CommentsCollection.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import type { IComment } from '@/types/comments';
 import { getComments } from '@/scripts/api/comments';
 import { cn } from '@/lib/utils';
-import { Player } from '@lottiefiles/react-lottie-player';
 import CommentItem from './CommentItem';
 import { arrToTree } from '@/helper/comment';
 
@@ -22,7 +21,7 @@ const CommentsCollection = ({ pageId, className = '' }) => {
 	}, []);
 	return loading ? (
 		<div className="flex text-neutral-200 items-center">
-			<Player src={'/lottie/loading.json'} loop autoplay className="w-20 h-20" />
+			<div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-600 border-t-gray-300" />
 			<div>评论区载入中</div>
 		</div>
 	) : (

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -17,7 +17,7 @@ import SMNavigation from './Nav/SMNavigation';
 		>
 	</div>
 	<div class="grow flex justify-center">
-		<Navigation client:load />
+		<Navigation client:idle />
 	</div>
 	<div class="flex flex-1 row-end-1 justify-center gap-4">
 		<SignatureLogo />
@@ -33,24 +33,25 @@ import SMNavigation from './Nav/SMNavigation';
 			><img src={avatar.src} class="rounded-2xl object-fill bg-cover w-11 h-11" /></a
 		>
 	</div>
-	<div class="text-white"><SMNavigation client:load /></div>
+	<div class="text-white"><SMNavigation client:idle /></div>
 </div>
 <script>
 	// 渐变背景
 	const progressiveBorder = () => {
 		const offsetY = window.scrollY;
-		const dom = document.querySelector('#header');
-		if (!dom) return;
-		if (offsetY < 20) {
-			dom.classList.remove('backdrop-blur-3xl');
-		} else if (!dom.classList.contains('backdrop-blur-3xl')) {
-			dom.classList.add('backdrop-blur-3xl');
-		}
-		if (offsetY < 400) {
-			dom.style['border-bottom'] = `1px solid rgb(75,85,99,${offsetY / 400})`;
-		} else {
-			dom.style['border-bottom'] = `1px solid rgb(75,85,99)})`;
-		}
+		const headers = document.querySelectorAll<HTMLElement>('#header');
+		headers.forEach((dom) => {
+			if (offsetY < 20) {
+				dom.classList.remove('backdrop-blur-3xl');
+			} else if (!dom.classList.contains('backdrop-blur-3xl')) {
+				dom.classList.add('backdrop-blur-3xl');
+			}
+			if (offsetY < 400) {
+				dom.style.borderBottom = `1px solid rgb(75,85,99,${offsetY / 400})`;
+			} else {
+				dom.style.borderBottom = '1px solid rgb(75,85,99)';
+			}
+		});
 	};
 	document.addEventListener('astro:page-load', progressiveBorder);
 	document.addEventListener('scroll', progressiveBorder, true);

--- a/src/components/HomePage/Home.astro
+++ b/src/components/HomePage/Home.astro
@@ -13,7 +13,7 @@ import homepagePhoto from '../../../public/image-1.png';
 		<h1>Check it out !</h1>
 		<!-- <span>Life is a Journey</span> -->
 		<h1 class="inline-block lg:mt-4">参与世界的变化 🌍</h1>
-		<SocialMedia client:load className="mt-10 gap-4 pl-0 mx-auto lg:mx-0 lg:mt-10" />
+		<SocialMedia client:visible className="mt-10 gap-4 pl-0 mx-auto lg:mx-0 lg:mt-10" />
 	</div>
 	<img src={homepagePhoto.src} class="rounded-3xl w-[300px]" />
 </section>

--- a/src/components/Nav/config.tsx
+++ b/src/components/Nav/config.tsx
@@ -21,7 +21,7 @@ export const MenuConfig = {
 				<path d="M467.14 44.84c-62.55-62.48-161.67-64.78-252.28 25.73-78.61 78.52-60.98 60.92-85.75 85.66-60.46 60.39-70.39 150.83-63.64 211.17l178.44-178.25c6.26-6.25 16.4-6.25 22.65 0s6.25 16.38 0 22.63L7.04 471.03c-9.38 9.37-9.38 24.57 0 33.94 9.38 9.37 24.6 9.37 33.98 0l66.1-66.03C159.42 454.65 279 457.11 353.95 384h-98.19l147.57-49.14c49.99-49.93 36.38-36.18 46.31-46.86h-97.78l131.54-43.8c45.44-74.46 34.31-148.84-16.26-199.36z" />
 			</svg>
 		),
-		href: baseURL + '/thoughts/1',
+		href: baseURL + '/thoughts/1/',
 	},
 	posts: {
 		title: '文章',
@@ -30,7 +30,7 @@ export const MenuConfig = {
 				<path d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2ZM10,16,7,17l1-3,7-7,2,2Z" />
 			</svg>
 		),
-		href: baseURL + '/posts/1',
+		href: baseURL + '/posts/1/',
 	},
 	friends: {
 		title: '友链',
@@ -85,7 +85,7 @@ export const MenuConfig = {
 				</g>
 			</svg>
 		),
-		href: baseURL + '/friends',
+		href: baseURL + '/friends/',
 	},
 	moments: {
 		title: '时刻',
@@ -95,7 +95,7 @@ export const MenuConfig = {
 				<path d="M12 6v6l4 2" stroke="#fff" strokeWidth="2" strokeLinecap="round" />
 			</svg>
 		),
-		href: baseURL + '/moments',
+		href: baseURL + '/moments/',
 	},
 	// message: {
 	// 	title: '留言',

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -29,24 +29,6 @@ const { width = 'max-w-6xl', showNeon = true, title } = Astro.props;
 		/>
 		<title>luckycc</title>
 
-		<!-- Matomo -->
-		<script is:inline>
-			var _paq = (window._paq = window._paq || []);
-			/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-			_paq.push(['trackPageView']);
-			_paq.push(['enableLinkTracking']);
-			(function () {
-				var u = 'https://luckycc.matomo.cloud/';
-				_paq.push(['setTrackerUrl', u + 'matomo.php']);
-				_paq.push(['setSiteId', '1']);
-				var d = document,
-					g = d.createElement('script'),
-					s = d.getElementsByTagName('script')[0];
-				g.async = true;
-				g.src = 'https://cdn.matomo.cloud/luckycc.matomo.cloud/matomo.js';
-				s.parentNode.insertBefore(g, s);
-			})();
-		</script>
 	</head>
 	<body class="bg-slate-900">
 		<main class="min-h-screen">
@@ -54,7 +36,7 @@ const { width = 'max-w-6xl', showNeon = true, title } = Astro.props;
 			<Header title={title} />
 			<slot />
 		</main>
-		<Toaster client:load />
+		<Toaster client:idle />
 		<Footer />
 	</body>
 </html>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -11,7 +11,7 @@ const title = frontmatter.title;
 ---
 
 <HomeLayout showNeon={true} isPost title={title}>
-	<BlurFade client:load className=`mx-auto max-w-6xl my-40 px-6 lg:px-40`>
+	<BlurFade client:idle className=`mx-auto max-w-6xl my-40 px-6 lg:px-40`>
 		<div class="flex font-serif">
 			<div class="flex flex-col gap-8 max-w-5xl text-white">
 				<div
@@ -44,7 +44,7 @@ const title = frontmatter.title;
 			{!!headings?.length && <Toc toc={headings} />}
 		</div>
 		<div class="bg-gray-500 h-px w-full mt-5"></div>
-		<Comments client:load pageId={url} pageTitle={title} />
+		<Comments client:visible pageId={url} pageTitle={title} />
 	</BlurFade>
 </HomeLayout>
 

--- a/src/pages/friends/index.astro
+++ b/src/pages/friends/index.astro
@@ -37,7 +37,7 @@ const friends: IFriend[] = [
 ---
 
 <HomeLayout>
-	<BlurFade client:load className="w-full mx-auto px-8 xl:w-[70%]">
+	<BlurFade client:idle className="w-full mx-auto px-8 xl:w-[70%]">
 		<Title title="Nice to meet you!" className="text-xl md:text-2xl lg:text-3xl" />
 		<FriendsCollection friends={friends} />
 	</BlurFade>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import '../styles/global.css';
 
 <!-- <link rel="stylesheet" href="/styles/global.css" /> -->
 <HomeLayout>
-	<BlurFade client:load className=`mx-auto max-w-6xl my-20 px-20`>
+	<BlurFade client:idle className=`mx-auto max-w-6xl my-20 px-20`>
 		<Home />
 		<Intro />
 	</BlurFade>

--- a/src/pages/interview/algorithm/index.astro
+++ b/src/pages/interview/algorithm/index.astro
@@ -8,7 +8,7 @@ const allPosts = await Astro.glob('./*.md');
 ---
 
 <HomeLayout>
-	<BlurFade client:load className=`mx-auto max-w-4xl px-20`>
+	<BlurFade client:idle className=`mx-auto max-w-4xl px-20`>
 		<Title title="算法笔记" />
 		<GridCollection posts={allPosts} />
 	</BlurFade>

--- a/src/pages/interview/index.astro
+++ b/src/pages/interview/index.astro
@@ -11,15 +11,15 @@ const posts = await Astro.glob('./*.md');
 ---
 
 <HomeLayout>
-	<BlurFade client:load className=`mx-auto max-w-4xl px-8 lg:px-20`>
+	<BlurFade client:idle className=`mx-auto max-w-4xl px-8 lg:px-20`>
 		<Title title="算法笔记" />
 		<GridCollection posts={algoPosts} />
 	</BlurFade>
-	<BlurFade client:load className=`mx-auto max-w-4xl px-8 lg:px-20`>
+	<BlurFade client:idle className=`mx-auto max-w-4xl px-8 lg:px-20`>
 		<Title title="前端面经" className="mt-10" />
 		<GridCollection posts={febasicPosts} />
 	</BlurFade>
-	<BlurFade client:load className=`mx-auto max-w-4xl px-8 lg:px-20`>
+	<BlurFade client:idle className=`mx-auto max-w-4xl px-8 lg:px-20`>
 		<Title title="文章" className="mt-10" />
 		<PostCollection posts={posts} />
 	</BlurFade>

--- a/src/pages/moments/index.astro
+++ b/src/pages/moments/index.astro
@@ -7,6 +7,6 @@ import Title from '@/components/Title.astro';
 <HomeLayout title="Moments">
 	<div class="mx-auto max-w-2xl px-6 lg:px-8 text-white font-serif">
 		<Title title="Moments" />
-		<MomentTimeline client:load limit={3} />
+		<MomentTimeline client:visible limit={3} />
 	</div>
 </HomeLayout>

--- a/src/pages/posts/[page].astro
+++ b/src/pages/posts/[page].astro
@@ -17,7 +17,7 @@ const { page } = Astro.props;
 ---
 
 <HomeLayout>
-	<BlurFade client:load className=`mx-auto max-w-4xl px-8 lg:px-20 text-white`>
+	<BlurFade client:idle className=`mx-auto max-w-4xl px-8 lg:px-20 text-white`>
 		<Title title="文章" />
 		<PostCollection posts={page.data} />
 		<Pagination

--- a/src/pages/thoughts/[page].astro
+++ b/src/pages/thoughts/[page].astro
@@ -26,7 +26,7 @@ const { page } = Astro.props;
 ---
 
 <HomeLayout>
-	<BlurFade client:load className=`mx-auto max-w-4xl px-8 lg:px-20 text-white`>
+	<BlurFade client:idle className=`mx-auto max-w-4xl px-8 lg:px-20 text-white`>
 		<Title title="日记/杂谈/非正式思考 📝" />
 		<PostCollection posts={page.data} />
 		<Pagination

--- a/src/scripts/api/comments/index.ts
+++ b/src/scripts/api/comments/index.ts
@@ -37,7 +37,6 @@ export const postComments = async (comment: z.infer<typeof formSchema>) => {
         },
         // credentials: "include",
         body: JSON.stringify(comment),
-    }).catch(e => {
     });
     const resObject = await response.json();
     return resObject.data;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -84,6 +84,36 @@
 	opacity: 0.9;
 }
 
+@media (max-width: 899px), (prefers-reduced-motion: reduce) {
+	.root {
+		filter: blur(72px) !important;
+		opacity: 0.5;
+	}
+
+	.root > section {
+		animation: none !important;
+	}
+
+	.animate-\[signatrue_linear_5s_infinite\],
+	.animate-\[signatruelogo_linear_5s_infinite\] {
+		animation: none !important;
+		fill: #fff !important;
+	}
+
+	.backdrop-blur,
+	.backdrop-blur-md,
+	.backdrop-blur-xl,
+	.backdrop-blur-3xl {
+		-webkit-backdrop-filter: none !important;
+		backdrop-filter: none !important;
+	}
+
+	#container {
+		filter: none !important;
+		will-change: auto !important;
+	}
+}
+
 /* Moments Timeline 样式 */
 .moments-timeline {
 	position: relative;


### PR DESCRIPTION
## Summary

This PR reduces mobile rendering pressure and fixes avoidable navigation/cache overhead that made the site feel hot, janky, and slow on phones.

## Root causes

- Internal links used non-trailing-slash URLs, causing extra redirects before static pages loaded.
- Static hashed assets, fonts, and images were not given long-lived cache headers.
- Multiple React/Astro islands hydrated on `client:load`, increasing main-thread work during page load.
- Mobile rendering had expensive effects: large fixed blurred background, backdrop blur, infinite SVG stroke animations, and BlurFade filters.
- Matomo script URL returned 404, adding a failed third-party request.
- The Lottie loading component pulled in a large client dependency and broke SSR during build.

## Changes

- Enable `trailingSlash: always` and update internal links/redirects to slash URLs.
- Add Caddy cache headers for static assets and HTML.
- Defer non-critical hydration from `client:load` to `client:idle` / `client:visible`.
- Reduce mobile/reduced-motion GPU-heavy effects.
- Remove the broken Matomo inline script.
- Replace Lottie loading animation with a lightweight CSS spinner.
- Fix existing TypeScript/build issues in header scroll handling and comment posting.

## Validation

- `pnpm build` passes.
- `astro check` reports 0 errors.
- Client comments chunk is significantly smaller after removing Lottie.